### PR TITLE
 Transition less files from Shadow DOM to a Light DOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Babel React Syntax Theme
 
-A simple colorful for Babel Javascript.
+A simple, colorful theme for Babel Javascript.
 
 ![](https://res.cloudinary.com/randagio13/image/upload/v1463329268/Example_xazaws.png)
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Babel React Syntax Theme
 
-A simple, colorful theme for Babel Javascript.
+A simple, colorful, syntax theme for Babel ES6 Javascript.
 
 ![](https://res.cloudinary.com/randagio13/image/upload/v1463329268/Example_xazaws.png)
 
 -------------------------------------------------------------------------------------------------------------
 
-**Note: You must use Atom v1.13 or above for this theme to work properly.
+**Note: You must use Atom v1.13 or above and have the Atom package: language-babel installed for this theme to work properly.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Babel React Syntax Theme
 
-A simple colorful for Babel ES6 Javascript.
+A simple colorful for Babel Javascript.
 
 ![](https://res.cloudinary.com/randagio13/image/upload/v1463329268/Example_xazaws.png)
+
+-------------------------------------------------------------------------------------------------------------
+
+**Note: You must use Atom v1.13 or above for this theme to work properly.

--- a/styles/base.less
+++ b/styles/base.less
@@ -10,6 +10,5 @@
 @import './languages/ruby';
 @import './languages/python';
 @import './languages/html';
-@import './languages/js';
 @import './languages/jsx';
 @import './languages/ts';

--- a/styles/editor.less
+++ b/styles/editor.less
@@ -1,8 +1,8 @@
 
 // Editor styles (background, gutter, guides)
 
-atom-text-editor, // <- remove when Shadow DOM can't be disabled
-:host {
+atom-text-editor // <- remove when Shadow DOM can't be disabled
+ {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
 

--- a/styles/language.less
+++ b/styles/language.less
@@ -1,260 +1,260 @@
 // Language syntax highlighting
 
-.comment {
+.syntax--comment {
   color: @syntax-comment;
   font-style: italic;
 }
 
-.entity {
+.syntax--entity {
 
-  &.name.type {
+  &.syntax--name.syntax--type {
     color: @hue-4;
   }
 
-  &.other.inherited-class {
+  &.syntax--other.syntax--inherited-class {
     color: @hue-3;
   }
 }
 
-.keyword {
+.syntax--keyword {
   color: @hue-3;
 
-  &.control {
+  &.syntax--control {
     color: @hue-3;
   }
 
-  &.operator {
+  &syntax--.syntax--operator {
     color: @mono-1;
-    &.new {
+    &.syntax--new {
       color: @carrot;
       font-style: italic;
     }
   }
 
-  &.other.special-method {
+  &.syntax--other.syntax--special-method {
     color: @hue-2;
   }
 
-  &.other.unit {
+  &.syntax--other.syntax--unit {
     color: @hue-6;
   }
 }
 
-.storage {
+.syntax--storage {
   color: @hue-3;
 
-  &.type {
-    &.annotation,
-    &.primitive {
+  &.syntax--type {
+    &.syntax--annotation,
+    &.syntax--primitive {
       color: @hue-3;
     }
-    &.function{
+    &.syntax--function{
       color:@hue-4;
     }
   }
 
-  &.modifier {
-    &.package,
-    &.import {
+  &.syntax--modifier {
+    &.syntax--package,
+    &.syntax--import {
       color: @mono-1;
     }
   }
 }
 
-.constant {
+.syntax--constant {
   color: @hue-6;
 
-  &.language {
+  &.syntax--language {
     color: @amethyst;
   }
 
-  &.character.escape {
+  &.syntax--character.syntax--escape {
     color: @hue-4;
   }
 
-  &.numeric {
+  &.syntax--numeric {
     color: @hue-6;
   }
 
-  &.other.color {
+  &.syntax--other.syntax--color {
     color: @hue-4;
   }
 
-  &.other.symbol {
+  &.syntax--other.syntax--symbol {
     color: @hue-4;
   }
 }
 
-.variable {
+.syntax--variable {
   color: @hue-4;
 
-  &.interpolation {
+  &.syntax--interpolation {
     color: @hue-5;
   }
 
-  &.parameter {
+  &.syntax--parameter {
     color: @orange;
   }
 }
 
-.string {
+.syntax--string {
   color: @hue-6;
 
 
-  &.regexp {
+  &.syntax--regexp {
     color: @hue-4;
 
-    .source.ruby.embedded {
+    .syntax--source.syntax--ruby.syntax--embedded {
       color: @hue-6-2;
     }
   }
 
-  &.other.link {
+  &.syntax--other.syntax--link {
     color: @hue-5;
   }
 }
 
-.punctuation {
-  &.definition {
-    &.comment {
+.syntax--punctuation {
+  &.syntax--definition {
+    &.syntax--comment {
       color: @syntax-comment;
     }
 
-    &.method-parameters,
-    &.function-parameters,
-    &.parameters,
-    &.separator,
-    &.seperator,
-    &.array {
+    &.syntax--method-parameters,
+    &.syntax--function-parameters,
+    &.syntax--parameters,
+    &.syntax--separator,
+    &.syntax--seperator,
+    &.syntax--array {
       color: @hue-4;
     }
 
-    &.heading,
-    &.identity {
+    &.syntax--heading,
+    &.syntax--identity {
       color: @hue-2;
     }
 
-    &.bold {
+    &.syntax--bold {
       color: @hue-6;
       font-weight: bold;
     }
 
-    &.italic {
+    &.syntax--italic {
       color: @hue-3;
       font-style: italic;
     }
   }
 
-  &.section {
-    &.embedded {
+  &.syntax--section {
+    &.syntax--embedded {
       color: @hue-4;
     }
 
-    &.method,
-    &.class,
-    &.inner-class {
+    &.syntax--method,
+    &.syntax--class,
+    &.syntax--inner-class {
       color: @hue-4;
     }
   }
 }
 
-.support {
-  &.class {
+.syntax--support {
+  &.syntax--class {
     color: @hue-4;
   }
 
-  &.type {
+  &.syntax--type {
     color: @hue-4;
   }
 
-  &.function  {
+  &.syntax--function  {
     color: @hue-4;
 
-    &.any-method {
+    &.syntax--any-method {
       color: @hue-2;
     }
   }
 }
 
-.entity {
-  &.name.function {
+.syntax--entity {
+  &.syntax--name.syntax--function {
     color: @hue-2;
   }
 
-  &.name.class,
-  &.name.type.class {
+  &.syntax--name.syntax--class,
+  &.syntax--name.syntax--type.syntax--class {
     color: @hue-6;
   }
 
-  &.name.section {
+  &.syntax--name.syntax--section {
     color: @hue-2;
   }
 
-  &.name.tag {
+  &.syntax--name.syntax--tag {
     color: @hue-3;
   }
 
-  &.other.attribute-name {
+  &.syntax--other.syntax--attribute-name {
     color: @hue-4;
 
-    &.id {
+    &.syntax--id {
       color: @hue-3;
     }
   }
 }
 
-.meta {
-  &.class {
+.syntax--meta {
+  &.syntax--class {
     color: @hue-6-2;
 
-    &.body {
+    &.syntax--body {
       color: @mono-1;
     }
   }
 
-  &.method-call,
-  &.method {
+  &.syntax--method-call,
+  &.syntax--method {
     color: @mono-1;
   }
 
-  &.definition {
-    &.variable {
+  &.syntax--definition {
+    &.syntax--variable {
       color: @hue-4;
     }
   }
 
-  &.link {
+  &.syntax--link {
     color: @hue-6;
   }
 
-  &.require {
+  &.syntax--require {
     color: @hue-2;
   }
 
-  &.selector {
+  &.syntax--selector {
     color: @hue-3;
   }
 
-  &.separator {
+  &.syntax--separator {
     background-color: #373b41;
     color: @mono-1;
   }
 
-  &.tag {
+  &.syntax--tag {
     color: @mono-1;
   }
 }
 
-.none {
+.syntax--none {
   color: @mono-1;
 }
 
-.invalid {
-  &.deprecated {
+.syntax--invalid {
+  &.syntax--deprecated {
     color: @syntax-deprecated-fg !important;
     background-color: @syntax-deprecated-bg !important;
   }
-  &.illegal {
+  &.syntax--illegal {
     color: @syntax-illegal-fg !important;
     background-color: @syntax-illegal-bg !important;
   }
@@ -262,42 +262,42 @@
 
 // Languages -------------------------------------------------
 
-.markup {
-  &.bold {
+.syntax--markup {
+  &.syntax--bold {
     color: @hue-6;
     font-weight: bold;
   }
 
-  &.changed {
+  &.syntax--changed {
     color: @hue-3;
   }
 
-  &.deleted {
+  &.syntax--deleted {
     color: @hue-5;
   }
 
-  &.italic {
+  &.syntax--italic {
     color: @hue-3;
     font-style: italic;
   }
 
-  &.heading .punctuation.definition.heading {
+  &.syntax--heading .syntax--punctuation.syntax--definition.syntax--heading {
     color: @hue-2;
   }
 
-  &.inserted {
+  &.syntax--inserted {
     color: @hue-4;
   }
 
-  &.list {
+  &.syntax--list {
     color: @hue-5;
   }
 
-  &.quote {
+  &.syntax--quote {
     color: @hue-6;
   }
 
-  &.raw {
+  &.syntax--raw {
     color: @hue-4;
   }
 }

--- a/styles/languages/cs.less
+++ b/styles/languages/cs.less
@@ -1,5 +1,5 @@
-.source.cs {
-  .keyword.operator {
+.syntax--source.syntax--cs {
+  .syntax--keyword.syntax--operator {
     color: @hue-3;
   }
 }

--- a/styles/languages/css.less
+++ b/styles/languages/css.less
@@ -1,24 +1,24 @@
-.source.css {
+.syntax--source.syntax--css {
 
   // highlight properties/values if they are supported
-  .property-name{
+  .syntax--property-name{
     color: @hue-5;
-    &.support {
+    &.syntax--support {
       font-style: italic;
     }
   }
 
-  .property-value {
+  .syntax--property-value {
     color: @mono-1;
-    &.support {
+    &.syntax--support {
       font-style: italic;
     }
-    &.constant{
+    &.syntax--constant{
       color: @mono-2;
     }
   }
 
-  .parent-selector.css{
+  .syntax--parent-selector.syntax--css{
     color: @hue-3;
   }
 

--- a/styles/languages/gfm.less
+++ b/styles/languages/gfm.less
@@ -1,16 +1,16 @@
-.source.gfm {
-  .markup {
+.syntax--source.syntax--gfm {
+  .syntax--markup {
     -webkit-font-smoothing: auto;
-    &.heading {
+    &.syntax--heading {
       color: @hue-5;
     }
 
-    &.link {
+    &.syntax--link {
       color: @hue-3;
     }
   }
 
-  .link .entity {
+  .syntax--link .syntax--entity {
     color: @hue-2;
   }
 }

--- a/styles/languages/html.less
+++ b/styles/languages/html.less
@@ -1,40 +1,40 @@
-.html {
+.syntax--html {
 
-  .meta.tag{
+  .syntax--meta.syntax--tag{
     color: @mono-1;
-    &.any {
+    &.syntax--any {
       color: @mono-1;
     }
   }
 
-  .entity.name.tag {
-    &.block, &.inline, &.name {
+  .syntax--entity.syntax--name.syntax--tag {
+    &.syntax--block, &.syntax--inline, &.syntax--name {
       color: @hue-3;
     }
   }
-  .entity.other.attribute-name{
+  .syntax--entity.syntax--other.syntax--attribute-name{
     color: @hue-4;
-    &.html{
+    &.syntax--html{
       color: @hue-4;
     }
-    &.id.html {
+    &.syntax--id.syntax--html {
       color: @hue-4;
     }
   }
 
-  .punctuation.separator.key-value {
+  .syntax--punctuation.syntax--separator.syntax--key-value {
     color: @mono-1;
   }
 
-  .string.quoted.double {
+  .syntax--string.syntax--quoted.syntax--double {
     color: @hue-6;
 
-    .punctuation.definition.string {
-      &.begin, &.end {
+    .syntax--punctuation.syntax--definition.syntax--string {
+      &.syntax--begin, &.syntax--end {
         color: @hue-6;
       }
 
-      .separator.key-value.html {
+      .syntax--separator.syntax--key-value.syntax--html {
         color: @hue-4;
       }
 

--- a/styles/languages/ini.less
+++ b/styles/languages/ini.less
@@ -1,5 +1,5 @@
-.source.ini {
-  .keyword.other.definition.ini {
+.syntax--source.syntax--ini {
+  .syntax--keyword.syntax--other.syntax--definition.syntax--ini {
     color: @hue-5;
   }
 }

--- a/styles/languages/java.less
+++ b/styles/languages/java.less
@@ -1,20 +1,20 @@
-.source.java {
-  .storage {
-    &.modifier.import {
+.syntax--source.syntax--java {
+  .syntax--storage {
+    &.syntax--modifier.syntax--import {
       color: @hue-6-2;
     }
 
-    &.type {
+    &.syntax--type {
       color: @hue-6-2;
     }
   }
 }
 
-.source.java-properties {
-  .meta.key-pair {
+.syntax--source.syntax--java-properties {
+  .syntax--meta.syntax--key-pair {
     color: @hue-5;
 
-    & > .punctuation {
+    & > .syntax--punctuation {
       color: @mono-1;
     }
   }

--- a/styles/languages/json.less
+++ b/styles/languages/json.less
@@ -1,31 +1,31 @@
-.source.json {
-  .meta.structure.dictionary.json {
-    & > .string.quoted.json {
-      & > .punctuation.string {
+.syntax--source.syntax--json {
+  .syntax--meta.syntax--structure.syntax--dictionary.syntax--json {
+    & > .syntax--string.syntax--quoted.syntax--json {
+      & > .syntax--punctuation.syntax--string {
         color: @hue-3;
       }
       color: @hue-3;
     }
   }
-  .punctuation.definition.array.begin.json, .punctuation.definition.array.end.json {
+  .syntax--punctuation.syntax--definition.syntax--array.syntax--begin.syntax--json, .syntax--punctuation.syntax--definition.syntax--array.syntax--end.syntax--json {
     font-weight: bold;
     color: @mono-1;
   }
-  .punctuation.definition.dictionary.begin.json,.punctuation.definition.dictionary.end.json{
+  .syntax--punctuation.syntax--definition.syntax--dictionary.syntax--begin.syntax--json,.syntax--punctuation.syntax--definition.syntax--dictionary.syntax--end.syntax--json{
     font-weight: bold;
   }
-  .meta.structure.dictionary.json, .meta.structure.array.json {
-    & > .value.json > .string.quoted.json {
+  .syntax--meta.syntax--structure.syntax--dictionary.syntax--json, .syntax--meta.syntax--structure.syntax--array.syntax--json {
+    & > .syntax--value.syntax--json > .syntax--string.syntax--quoted.syntax--json {
       color: @hue-6;
     }
-    & > .value.json > .string.quoted.json > .punctuation {
+    & > .syntax--value.syntax--json > .syntax--string.syntax--quoted.syntax--json > .syntax--punctuation {
       color: @hue-6;
     }
-    & > .constant.language.json {
+    & > .syntax--constant.syntax--language.syntax--json {
       color: @hue-1;
     }
   }
-  .constant.language {
+  .syntax--constant.syntax--language {
     color: @amethyst;
   }
 }

--- a/styles/languages/jsx.less
+++ b/styles/languages/jsx.less
@@ -1,132 +1,132 @@
-.source.jsx {
-  .entity.name.class.js {
+.syntax--source.syntax--jsx {
+  .syntax--entity.syntax--name.syntax--class.syntax--js {
     color: @petroil;
   }
-  .meta.group.braces.curly {
-    .support.type.object.console.js {
+  .syntax--meta.syntax--group.syntax--braces.syntax--curly {
+    .syntax--support.syntax--type.syntax--object.syntax--console.syntax--js {
       color: @i-purple;
     }
-    .support.function.console.js {
+    .syntax--support.syntax--function.syntax--console.syntax--js {
       color: #a389eb;
     }
-    .variable.language.this.js {
+    .syntax--variable.syntax--language.syntax--this.syntax--js {
       color: #ee3486;
     }
-    .meta.property.object.js {
-      .variable.other.property.js {
+    .syntax--meta.syntax--property.syntax--object.syntax--js {
+      .syntax--variable.syntax--other.syntax--property.syntax--js {
         color: @light-blue;
       }
     }
-    .variable.other.object.js {
+    .syntax--variable.syntax--other.syntax--object.syntax--js {
       color: @violet;
     }
-    .variable.other.readwrite.js {
+    .syntax--variable.syntax--other.syntax--readwrite.syntax--js {
       color: @green-highlighter;
     }
   }
-  .entity.name.tag{
+  .syntax--entity.syntax--name.syntax--tag{
     color: @hue-3;
   }
-  .constant.other.object.key.js {
-    .string.unquoted.js {
+  .syntax--constant.syntax--other.syntax--object.syntax--key.syntax--js {
+    .syntax--string.syntax--unquoted.syntax--js {
       color: #ff7569;
     }
   }
-  .meta.function-call.static.with-arguments.js {
-    .variable.other.class.js {
+  .syntax--meta.syntax--function-call.syntax--static.syntax--with-arguments.syntax--js {
+    .syntax--variable.syntax--other.syntax--class.syntax--js {
       color: @violet;
     }
   }
-  .meta.function-call.with-arguments.js {
-    .meta.tag.jsx {
-      .entity.other.attribute-name.jsx {
+  .syntax--meta.syntax--function-call.syntax--with-arguments.syntax--js {
+    .syntax--meta.syntax--tag.syntax--jsx {
+      .syntax--entity.syntax--other.syntax--attribute-name.syntax--jsx {
         color: #5db9e4;
       }
     }
   }
-  .meta.class.body.js {
-    .support.type.object.console.js {
+  .syntax--meta.syntax--class.syntax--body.syntax--js {
+    .syntax--support.syntax--type.syntax--object.syntax--console.syntax--js {
       color: #ee3486;
     }
-    .support.function.console.js {
+    .syntax--support.syntax--function.syntax--console.syntax--js {
       color: #bdc0f9;
     }
-    .variable.language.this.js {
+    .syntax--variable.syntax--language.syntax--this.syntax--js {
       color: #ee3486;
     }
-    .variable.other.property.static.js {
+    .syntax--variable.syntax--other.syntax--property.syntax--static.syntax--js {
       color: #bdc0f9;
     }
-    .variable.other.property.js {
+    .syntax--variable.syntax--other.syntax--property.syntax--js {
       color: @light-blue;
     }
-    .meta.property.object.js {
-      .variable.other.property.static.js {
+    .syntax--meta.syntax--property.syntax--object.syntax--js {
+      .syntax--variable.syntax--other.syntax--property.syntax--static.syntax--js {
         color: #bdc0f9;
       }
-      .variable.other.property.js {
+      .syntax--variable.syntax--other.syntax--property.syntax--js {
         color: @light-blue;
       }
     }
-    .meta.group.braces.curly {
-      .support.type.object.console.js {
+    .syntax--meta.syntax--group.syntax--braces.syntax--curly {
+      .syntax--support.syntax--type.syntax--object.syntax--console.syntax--js {
         color: @i-purple;
       }
-      .support.function.console.js {
+      .syntax--support.syntax--function.syntax--console.syntax--js {
         color: #a389eb;
       }
-      .variable.language.this.js {
+      .syntax--variable.syntax--language.syntax--this.syntax--js {
         color: #ee3486;
       }
-      .meta.property.class.js {
-        .variable.other.class.js {
+      .syntax--meta.syntax--property.syntax--class.syntax--js {
+        .syntax--variable.syntax--other.syntax--class.syntax--js {
           color: #cdd7f0;
         }
-        .variable.other.property.static.js {
+        .syntax--variable.syntax--other.syntax--property.syntax--static.syntax--js {
           color: #bdc0f9;
         }
       }
-      .meta.property.object.js {
-        .variable.other.property.js {
+      .syntax--meta.syntax--property.syntax--object.syntax--js {
+        .syntax--variable.syntax--other.syntax--property.syntax--js {
           color: @light-blue;
         }
       }
-      .variable.other.object.js {
+      .syntax--variable.syntax--other.syntax--object.syntax--js {
         color: @violet;
       }
-      .variable.other.readwrite.js {
+      .syntax--variable.syntax--other.syntax--readwrite.syntax--js {
         color: @green-highlighter;
       }
-      .meta.tag.jsx {
-        .entity.other.attribute-name.jsx {
+      .syntax--meta.syntax--tag.syntax--jsx {
+        .syntax--entity.syntax--other.syntax--attribute-name.syntax--jsx {
           color: #167ed4;
         }
       }
     }
-    .meta.function.arrow.js {
-      .variable.other.readwrite.js {
+    .syntax--meta.syntax--function.syntax--arrow.syntax--js {
+      .syntax--variable.syntax--other.syntax--readwrite.syntax--js {
         color: #f5b544;
       }
     }
-    .meta.group.braces.round {
-      .meta.tag.jsx {
-        .entity.other.attribute-name.jsx {
+    .syntax--meta.syntax--group.syntax--braces.syntax--round {
+      .syntax--meta.syntax--tag.syntax--jsx {
+        .syntax--entity.syntax--other.syntax--attribute-name.syntax--jsx {
           color: #5db9e4;
         }
       }
     }
   }
-  .meta.tag.jsx {
-    .entity.name.tag.open.jsx {
-      .support.class.component.open.jsx {
+  .syntax--meta.syntax--tag.syntax--jsx {
+    .syntax--entity.syntax--name.syntax--tag.syntax--open.syntax--jsx {
+      .syntax--support.syntax--class.syntax--component.syntax--open.syntax--jsx {
         color: @hue-3;
       }
     }
-    .entity.other.attribute-name.jsx {
+    .syntax--entity.syntax--other.syntax--attribute-name.syntax--jsx {
       color: #5db9e4;
     }
-    .entity.name.tag.close.jsx {
-      .support.class.component.close.jsx {
+    .syntax--entity.syntax--name.syntax--tag.syntax--close.syntax--jsx {
+      .syntax--support.syntax--class.syntax--component.syntax--close.syntax--jsx {
         color: @hue-3;
       }
     }

--- a/styles/languages/python.less
+++ b/styles/languages/python.less
@@ -1,9 +1,9 @@
-.source.python {
-  .keyword.operator.logical.python {
+.syntax--source.syntax--python {
+  .syntax--keyword.syntax--operator.syntax--logical.syntax--python {
     color: @hue-3;
   }
 
-  .variable.parameter {
+  .syntax--variable.syntax--parameter {
     color: @hue-6;
   }
 }

--- a/styles/languages/ruby.less
+++ b/styles/languages/ruby.less
@@ -1,5 +1,5 @@
-.source.ruby {
-  .constant.other.symbol > .punctuation {
+.syntax--source.syntax--ruby {
+  .syntax--constant.syntax--other.syntax--symbol > .syntax--punctuation {
     color: inherit;
   }
 }

--- a/styles/languages/ts.less
+++ b/styles/languages/ts.less
@@ -1,5 +1,5 @@
-.source.ts {
-  .storage.type.variable{
+.syntax--source.syntax--ts {
+  .syntax--storage.syntax--type.syntax--variable{
     color: @amethyst;
   }
 }


### PR DESCRIPTION
Changes include:
- Removed `:host` from `.atom-text-editor` in `editor.less`
- Added `.syntax--` to all former Shadow DOM class names
- Updated minimum Atom version in package.json and updated README.md for requirements